### PR TITLE
Sepolia support

### DIFF
--- a/charts/devnet/templates/chains/virtual/eth/service.yaml
+++ b/charts/devnet/templates/chains/virtual/eth/service.yaml
@@ -18,14 +18,6 @@ spec:
       port: 3500
       targetPort: 3500
       nodePort: 30500
-    - name: p2p-tcp
-      protocol: TCP
-      port: 30303
-      nodePort: 30303
-    - name: p2p-udp
-      protocol: UDP
-      port: 30303
-      nodePort: 30303
     - name: geth-http
       protocol: TCP
       port: 8545
@@ -36,6 +28,15 @@ spec:
       port: 8551
       targetPort: 8551
       nodePort: 30551
+    - name: p2p-tcp
+      protocol: TCP
+      port: 30303
+      nodePort: 30303
+    - name: p2p-udp
+      protocol: UDP
+      port: 30303
+      nodePort: 30303
+
 
 {{- end }}
 {{- end }}

--- a/charts/devnet/templates/chains/virtual/eth/service.yaml
+++ b/charts/devnet/templates/chains/virtual/eth/service.yaml
@@ -28,15 +28,6 @@ spec:
       port: 8551
       targetPort: 8551
       nodePort: 30551
-    - name: p2p-tcp
-      protocol: TCP
-      port: 30303
-      nodePort: 30303
-    - name: p2p-udp
-      protocol: UDP
-      port: 30303
-      nodePort: 30303
-
 
 {{- end }}
 {{- end }}

--- a/charts/devnet/templates/chains/virtual/eth/service.yaml
+++ b/charts/devnet/templates/chains/virtual/eth/service.yaml
@@ -18,6 +18,14 @@ spec:
       port: 3500
       targetPort: 3500
       nodePort: 30500
+    - name: p2p-tcp
+      protocol: TCP
+      port: 30303
+      nodePort: 30303
+    - name: p2p-udp
+      protocol: UDP
+      port: 30303
+      nodePort: 30303
     - name: geth-http
       protocol: TCP
       port: 8545

--- a/charts/devnet/templates/chains/virtual/eth/statefulset.yaml
+++ b/charts/devnet/templates/chains/virtual/eth/statefulset.yaml
@@ -123,10 +123,10 @@ spec:
         name: ethereum
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        storageClassName: hostpath
+        storageClassName: {{ $chain.storageClassName }}
         resources:
           requests:
-            storage: 10Gi
+            storage: {{ $chain.storage }}
 
 {{- end }}
 {{- end }}

--- a/charts/devnet/templates/chains/virtual/eth/statefulset.yaml
+++ b/charts/devnet/templates/chains/virtual/eth/statefulset.yaml
@@ -39,6 +39,7 @@ spec:
           volumeMounts:
             - name: ethereum
               mountPath: /ethereum
+        {{- if not $chain.joinNetwork }}
         - name: prysm-beacon-init
           image: {{ $chain.prysmCtl.image }}
           command: {{ $chain.prysmCtl.command }}
@@ -52,7 +53,6 @@ spec:
             - name: config
               mountPath: /etc/config
               readOnly: true
-        {{- if not $chain.joinNetwork }}
         - name: geth-genesis-init
           image: {{ $chain.geth.image }}
           command: ['sh', '-c', "echo {{$chain.geth}}; if [ -e /ethereum/.init ]; then exit 0; fi; geth init --datadir=/ethereum/execution /etc/config/genesis.json"]
@@ -127,6 +127,23 @@ spec:
               mountPath: /etc/secrets
               readOnly: true
           resources: {{- include "getResourceObject" $chain.beaconChain.resources | trim | nindent 12 }}
+        {{- if $chain.validator.enabled }}
+        - name: validator
+          image: {{ $chain.validator.image }}
+          command: {{ $chain.validator.command }}
+          args:
+            {{- range $arg := $chain.validator.args }}
+            - {{ $arg -}}
+            {{ end }}
+          workingDir: /ethereum/consensus
+          volumeMounts:
+            - name: ethereum
+              mountPath: /ethereum
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+          resources: {{- include "getResourceObject" $chain.beaconChain.resources | trim | nindent 12 }}
+      {{- end }}
       {{- include "imagePullSecrets" $chain | indent 6 }}
       volumes:
         - name: secrets

--- a/charts/devnet/templates/chains/virtual/eth/statefulset.yaml
+++ b/charts/devnet/templates/chains/virtual/eth/statefulset.yaml
@@ -91,10 +91,6 @@ spec:
               containerPort: 8545
             - name: geth-authrpc
               containerPort: 8551
-            - name: p2p-tcp
-              containerPort: 30303
-            - name: p2p-udp
-              containerPort: 30303
           volumeMounts:
             - name: ethereum
               mountPath: /ethereum

--- a/charts/devnet/templates/chains/virtual/eth/statefulset.yaml
+++ b/charts/devnet/templates/chains/virtual/eth/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
             rm -rf /ethereum/{execution,consensus}; \
             mkdir -p /ethereum/consensus/{beacon,validator} /ethereum/execution \
             && cd /ethereum/consensus; \
-            stat genesis.ssz || wget -S https://github.com/eth-clients/eth2-networks/raw/master/shared/prater/genesis.ssz"]
+            stat genesis.ssz || wget -S {{ $chain.genesisStateUrl }};" ]
           volumeMounts:
             - name: ethereum
               mountPath: /ethereum
@@ -40,19 +40,6 @@ spec:
           volumeMounts:
             - name: ethereum
               mountPath: /ethereum
-        - name: prysm-beacon-init
-          image: {{ $chain.prysmCtl.image }}
-          command: {{ $chain.prysmCtl.command }}
-          args:
-            {{- range $arg := $chain.prysmCtl.args }}
-            - {{ $arg -}}
-            {{ end }}
-          volumeMounts:
-            - name: ethereum
-              mountPath: /ethereum
-            - name: config
-              mountPath: /etc/config
-              readOnly: true
         - name: geth-account-init
           image: {{ $chain.geth.image }}
           command: ['sh', '-c', "if [ -e /ethereum/.init ]; then exit 0; fi; geth --datadir=/ethereum/execution account import --password /dev/null /etc/secrets/secret.json"]
@@ -61,15 +48,6 @@ spec:
               mountPath: /ethereum
             - name: secrets
               mountPath: /etc/secrets
-              readOnly: true
-        - name: geth-genesis-init
-          image: {{ $chain.geth.image }}
-          command: ['sh', '-c', "if [ -e /ethereum/.init ]; then exit 0; fi; geth init --datadir=/ethereum/execution /etc/config/genesis.json"]
-          volumeMounts:
-            - name: ethereum
-              mountPath: /ethereum
-            - name: config
-              mountPath: /etc/config
               readOnly: true
         - name: init-done
           image: alpine/openssl
@@ -90,6 +68,10 @@ spec:
               containerPort: 8545
             - name: geth-authrpc
               containerPort: 8551
+            - name: p2p-tcp
+              containerPort: 30303
+            - name: p2p-udp
+              containerPort: 30303
           volumeMounts:
             - name: ethereum
               mountPath: /ethereum
@@ -123,24 +105,6 @@ spec:
               readOnly: true
             - name: secrets
               mountPath: /etc/secrets
-              readOnly: true
-          resources:
-            requests:
-              cpu: 100m
-              memory: 1Gi
-        - name: validator
-          image: {{ $chain.validator.image }}
-          command: {{ $chain.validator.command }}
-          args:
-            {{- range $arg := $chain.validator.args }}
-            - {{ $arg -}}
-            {{ end }}
-          workingDir: /ethereum/consensus
-          volumeMounts:
-            - name: ethereum
-              mountPath: /ethereum
-            - name: config
-              mountPath: /etc/config
               readOnly: true
           resources:
             requests:

--- a/charts/devnet/templates/chains/virtual/eth/statefulset.yaml
+++ b/charts/devnet/templates/chains/virtual/eth/statefulset.yaml
@@ -5,7 +5,6 @@
 {{ $defaultChain := get $.Values.defaultChains $chain.subtype | default dict }}
 {{ $chain = merge $chain $defaultChain }}
 
-
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -40,6 +39,30 @@ spec:
           volumeMounts:
             - name: ethereum
               mountPath: /ethereum
+        - name: prysm-beacon-init
+          image: {{ $chain.prysmCtl.image }}
+          command: {{ $chain.prysmCtl.command }}
+          args:
+            {{- range $arg := $chain.prysmCtl.args }}
+            - {{ $arg -}}
+            {{ end }}
+          volumeMounts:
+            - name: ethereum
+              mountPath: /ethereum
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+        {{- if not $chain.joinNetwork }}
+        - name: geth-genesis-init
+          image: {{ $chain.geth.image }}
+          command: ['sh', '-c', "echo {{$chain.geth}}; if [ -e /ethereum/.init ]; then exit 0; fi; geth init --datadir=/ethereum/execution /etc/config/genesis.json"]
+          volumeMounts:
+            - name: ethereum
+              mountPath: /ethereum
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+        {{- end }}
         - name: geth-account-init
           image: {{ $chain.geth.image }}
           command: ['sh', '-c', "if [ -e /ethereum/.init ]; then exit 0; fi; geth --datadir=/ethereum/execution account import --password /dev/null /etc/secrets/secret.json"]
@@ -78,10 +101,7 @@ spec:
             - name: secrets
               mountPath: /etc/secrets
               readOnly: true
-          resources:
-            requests:
-              cpu: 100m
-              memory: 1Gi
+          resources: {{- include "getResourceObject" $chain.geth.resources | trim | nindent 12 }}
         - name: beacon-chain
           image: {{ $chain.beaconChain.image }}
           command: {{ $chain.beaconChain.command }}
@@ -106,10 +126,7 @@ spec:
             - name: secrets
               mountPath: /etc/secrets
               readOnly: true
-          resources:
-            requests:
-              cpu: 100m
-              memory: 1Gi
+          resources: {{- include "getResourceObject" $chain.beaconChain.resources | trim | nindent 12 }}
       {{- include "imagePullSecrets" $chain | indent 6 }}
       volumes:
         - name: secrets

--- a/charts/devnet/values.yaml
+++ b/charts/devnet/values.yaml
@@ -244,6 +244,7 @@ defaultChains:
     repo: https://github.com/umee-network/umee
   eth:
     network: sepolia
+    storageClassName: hostpath
     genesisStateUrl: https://github.com/eth-clients/merge-testnets/blob/main/sepolia/genesis.ssz
     prysmCtl:
       enabled: true

--- a/charts/devnet/values.yaml
+++ b/charts/devnet/values.yaml
@@ -243,7 +243,10 @@ defaultChains:
     coinType: 118
     repo: https://github.com/umee-network/umee
   eth:
+    network: sepolia
+    genesisStateUrl: https://github.com/eth-clients/merge-testnets/blob/main/sepolia/genesis.ssz
     prysmCtl:
+      enabled: true
       image: gcr.io/prysmaticlabs/prysm/cmd/prysmctl
       command: ["/app/cmd/prysmctl/prysmctl"]
       args:
@@ -290,6 +293,7 @@ defaultChains:
         - --contract-deployment-block=0
         - --suggested-fee-recipient=0x123463a4B065722E99115D6c222f267d9cABb524
     validator:
+      enabled: true
       image: gcr.io/prysmaticlabs/prysm/validator:v4.0.7
       command: ["/app/cmd/validator/validator"]
       args:

--- a/charts/devnet/values.yaml
+++ b/charts/devnet/values.yaml
@@ -246,8 +246,8 @@ defaultChains:
     network: sepolia
     storageClassName: hostpath
     genesisStateUrl: https://github.com/eth-clients/merge-testnets/blob/main/sepolia/genesis.ssz
+    joinNetwork: false
     prysmCtl:
-      enabled: true
       image: gcr.io/prysmaticlabs/prysm/cmd/prysmctl
       command: ["/app/cmd/prysmctl/prysmctl"]
       args:
@@ -294,7 +294,7 @@ defaultChains:
         - --contract-deployment-block=0
         - --suggested-fee-recipient=0x123463a4B065722E99115D6c222f267d9cABb524
     validator:
-      enabled: true
+      enabled: false
       image: gcr.io/prysmaticlabs/prysm/validator:v4.0.7
       command: ["/app/cmd/validator/validator"]
       args:

--- a/charts/devnet/values.yaml
+++ b/charts/devnet/values.yaml
@@ -256,7 +256,7 @@ defaultChains:
         - --output-ssz=/ethereum/consensus/genesis.ssz
         - --chain-config-file=/etc/config/config.yml
     geth:
-      image: ethereum/client-go:v1.10.26
+      image: ethereum/client-go:v1.12.0
       args:
         - --nodiscover
         - --http


### PR DESCRIPTION
```
chains:
- name: ethereum
  type: virtual
  subtype: eth
  numValidators: 1
  prysmCtl:
    enabled: false
  geth:
    image: ethereum/client-go:v1.10.26
    args:
      - --sepolia
      - --http
      - --http.api=eth,net,engine,admin
      - --authrpc.jwtsecret=/etc/secrets/jwt.hex
      - --datadir=/ethereum/execution
      - --password=/dev/null

  beaconChain:
    args:
      - --sepolia
      - --datadir=/ethereum/consensus/beacon
      - --checkpoint-sync-url=https://beaconstate-sepolia.chainsafe.io
      - --genesis-beacon-api-url=https://beaconstate-sepolia.chainsafe.io
      - --execution-endpoint=http://localhost:8551
      - --accept-terms-of-use
      - --suggested-fee-recipient=0x123463a4B065722E99115D6c222f267d9cABb524
      - --jwt-secret=/etc/secrets/jwt.hex

```