### PR TITLE
Ds/explorer

### DIFF
--- a/charts/devnet/templates/chains/cosmos/service.yaml
+++ b/charts/devnet/templates/chains/cosmos/service.yaml
@@ -10,9 +10,11 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ $chain.name }}-genesis
   annotations:
+    {{- if eq $chain.platform "gke" }}
     cloud.google.com/backend-config: '{"ports": {
     "rest": "rest-hc-config"
     }}'
+    {{- end }}
 spec:
   {{- if $chain.external }}
   type: LoadBalancer

--- a/charts/devnet/templates/chains/cosmos/service.yaml
+++ b/charts/devnet/templates/chains/cosmos/service.yaml
@@ -9,6 +9,10 @@ metadata:
   name: {{ $chain.name }}-genesis
   labels:
     app.kubernetes.io/name: {{ $chain.name }}-genesis
+  annotations:
+    cloud.google.com/backend-config: '{"ports": {
+    "rest": "rest-hc-config"
+    }}'
 spec:
   {{- if $chain.external }}
   type: LoadBalancer

--- a/charts/devnet/templates/explorer.yaml
+++ b/charts/devnet/templates/explorer.yaml
@@ -64,6 +64,8 @@ spec:
           volumeMounts:
             - mountPath: /home/explorer/chains/mainnet
               name: explorer-configs
+            - mountPath: /home/explorer/chains/testnet
+              name: explorer-configs
           readinessProbe:
             tcpSocket:
               port: 8080
@@ -100,7 +102,7 @@ data:
       {{- if not $chain.endpoints.rest }}
       "api": "http://{{ $host }}:{{ $chain.ports.rest }}",
       {{ else }}
-      "api": "$chain.endpoints.rest",
+      "api": "{{ $chain.endpoints.rest }}",
       {{- end }}
       {{- if not $chain.endpoints.rpc }}
       "rpc": [
@@ -108,7 +110,7 @@ data:
       ],
       {{ else }}
       "rpc": [
-        "$chain.endpoints.rpc"
+        "{{ $chain.endpoints.rpc }}"
       ],
       {{- end }}
       "snapshot_provider": "",

--- a/charts/devnet/templates/explorer.yaml
+++ b/charts/devnet/templates/explorer.yaml
@@ -6,11 +6,15 @@ metadata:
   name: explorer
   labels:
     app.kubernetes.io/name: explorer
+  annotations:
+    cloud.google.com/backend-config: '{"ports": {
+    "http": "explorer-hc-config"
+    }}'
 spec:
   {{- if .Values.explorer.external }}
   type: LoadBalancer
   {{- else }}
-  clusterIP: None
+  type: ClusterIP
   {{- end }}
   ports:
     - name: http
@@ -93,11 +97,20 @@ data:
     {
       "chain_name": "{{ $chain.name }}",
       "coingecko": "{{ $chain.type }}",
+      {{- if not $chain.endpoints.rest }}
       "api": "http://{{ $host }}:{{ $chain.ports.rest }}",
+      {{ else }}
+      "api": "$chain.endpoints.rest",
+      {{- end }}
+      {{- if not $chain.endpoints.rpc }}
       "rpc": [
-        "http://{{ $host }}:{{ $chain.ports.rpc }}",
         "http://{{ $host }}:{{ $chain.ports.rpc }}"
       ],
+      {{ else }}
+      "rpc": [
+        "$chain.endpoints.rpc"
+      ],
+      {{- end }}
       "snapshot_provider": "",
       "sdk_version": "0.45.6",
       "coin_type": "{{ $chain.coinType }}",

--- a/charts/devnet/templates/explorer.yaml
+++ b/charts/devnet/templates/explorer.yaml
@@ -7,9 +7,11 @@ metadata:
   labels:
     app.kubernetes.io/name: explorer
   annotations:
+    {{- if eq .Values.explorer.platform "gke" }}
     cloud.google.com/backend-config: '{"ports": {
     "http": "explorer-hc-config"
     }}'
+    {{- end }}
 spec:
   {{- if .Values.explorer.external }}
   type: LoadBalancer

--- a/charts/devnet/values.schema.json
+++ b/charts/devnet/values.schema.json
@@ -291,6 +291,17 @@
             },
             "additionalProperties": false
           },
+          "endpoints": {
+             "type": "object",
+	      "properties": {
+		  "rest": {
+		      "type": "string"
+		  },
+		  "rpc": {
+		      "type": "string"
+		  }
+	      }
+	  },
           "ports": {
             "type": "object",
             "properties": {

--- a/charts/devnet/values.schema.json
+++ b/charts/devnet/values.schema.json
@@ -127,6 +127,12 @@
               "virtual"
             ]
           },
+	  "platform": {
+            "type": "string",
+            "enum": [
+              "gke"
+            ]
+          },
           "numValidators": {
             "type": "number",
             "exclusiveMinimum": 0


### PR DESCRIPTION
- Add annotations for GCP backendconfig healthchecks to cosmos service.yaml and explorer.yaml templates
- Mount explorer-configs to testnet AND mainnet directories to avoid issues auto-detecting "testnet" in the host
-  Update explorer configs to prefer explicit rest/rpc endpoints if they exists in the chain configs and update the values schema to allow these new fields.